### PR TITLE
Fix probs with selenium/standalone-firefox:3.5.0

### DIFF
--- a/lib/api/protocol.js
+++ b/lib/api/protocol.js
@@ -1386,6 +1386,14 @@ module.exports = function(Nightwatch) {
   }
 
   function postRequest(path, data, callback) {
+    var validateElementEntry = function (result) {
+      var ELEMENT_UID = 'element-6066-11e4-a52e-4f735466cecf';
+      if (!result.ELEMENT && result[ELEMENT_UID]) {
+        result.ELEMENT = result[ELEMENT_UID];
+        delete result[ELEMENT_UID];
+      }
+      return result;
+    };
     if (arguments.length === 2 && typeof data === 'function') {
       callback = data;
       data = '';
@@ -1395,7 +1403,16 @@ module.exports = function(Nightwatch) {
       method : 'POST',
       data : data || ''
     };
-    return sendRequest(options, callback);
+    return sendRequest(options, function(result) {
+      if (/\/element$/.test(options.path) && result.value) {
+        result.value = validateElementEntry(result.value);
+      } else if (/\/elements$/.test(options.path) && result.value[0]) {
+        result.value[0] = validateElementEntry(result.value[0]);
+      }
+      if (typeof callback === 'function') {
+        callback.call(this, result);
+      }
+    });
   }
 
   function sendRequest(options, callback) {


### PR DESCRIPTION
After upgrade `selenium/standalone-firefox` from `3.4.0` to `3.5.0` (or above) project tests are fail.
```
            loginPage.navigate()
                .waitForElementVisible('#app', Helper.maxLoadingTime);
```
Look like `nightwatch` wait entry `ELEMENT`, but latest `gecko` return `element-6066-11e4-a52e-4f735466cecf` instead (specification https://w3c.github.io/webdriver/webdriver-spec.html#elements)


## Expected Behavior 
with version 3.4.0 all work fine
```
INFO Response 200 POST /wd/hub/session/cf0426b6-2d16-4142-a018-8748b1acb8fe/elements (176ms) { state: 'success',
  sessionId: 'cf0426b6-2d16-4142-a018-8748b1acb8fe',
  hCode: 438605693,
  value: [ { ELEMENT: '0' } ],
  class: 'org.openqa.selenium.remote.Response',
  status: 0 }
INFO Request: GET /wd/hub/session/cf0426b6-2d16-4142-a018-8748b1acb8fe/element/0/displayed 
 - data:   
 - headers:  {"Accept":"application/json"}
INFO Response 200 GET /wd/hub/session/cf0426b6-2d16-4142-a018-8748b1acb8fe/element/0/displayed (213ms) { state: 'success',
  sessionId: 'cf0426b6-2d16-4142-a018-8748b1acb8fe',
  hCode: 562104897,
  value: true,
  class: 'org.openqa.selenium.remote.Response',
  status: 0 }
LOG     → Completed command waitForElementVisible (395 ms)
LOG     → Completed command useCss (1 ms)
```
https://travis-ci.org/instrumentisto/vue-app-example/builds/280784271


## Actual Behavior
In versions 3.5.0 or above
```
INFO Response 200 POST /wd/hub/session/96ea1cdc-63d1-486e-bd30-68ace2968fa3/elements (150ms) { state: 'success',
  sessionId: null,
  hCode: 1090440510,
  value: 
   [ { 'element-6066-11e4-a52e-4f735466cecf': '2a7b784d-1585-4f3c-b562-cc5f665c9228' } ],
  class: 'org.openqa.selenium.remote.Response',
  status: 0 }
INFO Request: GET /wd/hub/session/96ea1cdc-63d1-486e-bd30-68ace2968fa3/element/undefined/displayed 
 - data:   
 - headers:  {"Accept":"application/json"}
ERROR Response 500 GET /wd/hub/session/96ea1cdc-63d1-486e-bd30-68ace2968fa3/element/undefined/displayed (152ms) { state: 'javascript error',
  sessionId: null,
  hCode: 1848680964,
  value: 
   { additionalInformation: '\nDriver info: driver.version: unknown',
     localizedMessage: 'Element reference not seen before: undefined\nBuild info: version: \'3.5.0\', revision: \'8def36e068\', time: \'2017-08-10T23:00:22.093Z\'\nSystem info: host: \'2143c01b6db5\', ip: \'172.18.0.5\', os.name: \'Linux\', os.arch: \'amd64\', os.version: \'4.4.0-93-generic\', java.version: \'1.8.0_131\'\nDriver info: driver.version: unknown',

```
https://travis-ci.org/instrumentisto/vue-app-example/builds/280778475


